### PR TITLE
Utf8 support

### DIFF
--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -694,7 +694,7 @@ class OGame(object):
             is_idle = box.find('td', {'class': 'idle'}) is not None
             res[names[idx]] = []
             if not is_idle:
-                name = box.find('th').text
+                name = box.find('th').text.encode('utf8')
                 short_name = ''.join(name.split())
                 code = get_code(short_name)
                 desc = box.find('td', {'class': 'desc'}).text

--- a/ogame/constants.py
+++ b/ogame/constants.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 Buildings = {'MetalMine': 1,
              'CrystalMine': 2,
              'DeuteriumSynthesizer': 3,
@@ -18,8 +20,13 @@ Buildings = {'MetalMine': 1,
              'Fusiecentrale': 12,
              'Metaalopslag': 22,
              'Kristalopslag': 23,
-             'Deuteriumtank': 24}
+             'Deuteriumtank': 24,
 
+             #FR
+             'Minedemétal': 1,
+             'Minedecristal': 2,
+             'Synthétiseurdedeutérium': 3,
+             'Centraleélectriquesolaire': 4}
 
 Facilities = {'AllianceDepot': 34,
               'RoboticsFactory': 14,
@@ -38,7 +45,10 @@ Facilities = {'AllianceDepot': 34,
               'Raketsilo': 44,
               'Nanorobotfabriek': 15,
               'Terravormer': 33,
-              'Ruimtewerf': 36}
+              'Ruimtewerf': 36,
+              
+              #FR
+	      'Usinederobots': 14}
 
 
 Defense = {'RocketLauncher': 401,


### PR DESCRIPTION
In the ogame/__init__.py : 
The overview in french language can return a string in utf8 (Minedemétal for example)

In the ogame/constants.py : 
 Adding the utf8 encoding in the constants.py and some buildings in french. 
