### PR TITLE
Fixing index Supplies class

### DIFF
--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -281,7 +281,7 @@ class OGame(object):
     def supply(self, id):
         response = self.session.get(self.index_php + 'page=ingame&component=supplies&cp={}'.format(id)).text
         bs4 = self.BS4(response)
-        levels = [int(level['data-value']) for level in bs4.find_all('span', {'class': 'level', 'data-value': True})]
+        levels = [int(level['data-value']) for level in bs4.find_all('span', {'data-value': True})]
         status = [status['data-status'] for status in bs4.find_all('li', {'class': 'technology'})]
 
         class Supply:
@@ -297,9 +297,9 @@ class OGame(object):
             deuterium_mine = Supply(2)
             solar_plant = Supply(3)
             fusion_plant = Supply(4)
-            metal_storage = Supply(5)
-            crystal_storage = Supply(6)
-            deuterium_storage = Supply(7)
+            metal_storage = Supply(7)
+            crystal_storage = Supply(8)
+            deuterium_storage = Supply(9)
 
         return Supplies
 


### PR DESCRIPTION
The {'class': 'level'} filter makes ignore two Supplies ( which hold a class : "bonus", so it returns just 8 rather than 10.  This alters the order and makes to report a wrong status for 'is_posible' in metal_storage,crystal_storage,deuterium_storage.

Deleting {'class':'level'} and reassigning index for Supplies class fix it.