### PR TITLE
Fixing index Supplies class

### DIFF
--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -110,7 +110,7 @@ class OGame(object):
 
     def test(self):
         try:
-            import pruebas
+            import test
         except ImportError:
             import ogame.test as test
         test.UnittestOgame.empire = self

--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -306,7 +306,7 @@ class OGame(object):
     def facilities(self, id):
         response = self.session.get(self.index_php + 'page=ingame&component=facilities&cp={}'.format(id)).text
         bs4 = self.BS4(response)
-        levels = [int(level['data-value']) for level in bs4.find_all(class_='level')]
+        levels = [int(level['data-value']) for level in bs4.find_all('span', {'class': 'level', 'data-value': True})]
         status = [status['data-status'] for status in bs4.find_all('li', {'class': 'technology'})]
 
         class Facility:

--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -110,7 +110,7 @@ class OGame(object):
 
     def test(self):
         try:
-            import test
+            import pruebas
         except ImportError:
             import ogame.test as test
         test.UnittestOgame.empire = self
@@ -281,7 +281,7 @@ class OGame(object):
     def supply(self, id):
         response = self.session.get(self.index_php + 'page=ingame&component=supplies&cp={}'.format(id)).text
         bs4 = self.BS4(response)
-        levels = [int(level['data-value']) for level in bs4.find_all('span', {'class': 'level', 'data-value': True})]
+        levels = [int(level['data-value']) for level in bs4.find_all('span', {'data-value': True})]
         status = [status['data-status'] for status in bs4.find_all('li', {'class': 'technology'})]
 
         class Supply:


### PR DESCRIPTION
The {'class': 'level'} filter makes ignore two Supplies ( which hold a class : "bonus", so it returns just 8 rather than 10. This alters the order and makes to report a wrong status for 'is_posible' in metal_storage,crystal_storage,deuterium_storage.

Deleting {'class':'level'} and reassigning index for Supplies class fix it.