### PR TITLE
Updated supplies order, because new website layout

### DIFF
--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -339,9 +339,9 @@ class OGame(object):
             deuterium_mine = Supply(2)
             solar_plant = Supply(3)
             fusion_plant = Supply(4)
-            metal_storage = Supply(5)
-            crystal_storage = Supply(6)
-            deuterium_storage = Supply(7)
+            metal_storage = Supply(7)
+            crystal_storage = Supply(8)
+            deuterium_storage = Supply(9)
 
         return Supplies
 


### PR DESCRIPTION
Earlyer fusion_plant was right before metal_storage in the OGame supply html, but now there are two ships in between metal_storage and fusion_plant, what means that the order of the html elements changed aswell, and so this is the update for this