### PR TITLE
Supply index on Supplies class updated

### DIFF
--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -337,9 +337,11 @@ class OGame(object):
             deuterium_mine = Supply(2)
             solar_plant = Supply(3)
             fusion_plant = Supply(4)
-            metal_storage = Supply(5)
-            crystal_storage = Supply(6)
-            deuterium_storage = Supply(7)
+            # solar_satellite = Supply(5)
+            # crawler = Supply(6)
+            metal_storage = Supply(7)
+            crystal_storage = Supply(8)
+            deuterium_storage = Supply(9)
 
         return Supplies
 


### PR DESCRIPTION
Updated indexes of Supplies class, skipping index 5 and 6  because they now point to the solar satellite and tracker.

Tested that metal storage, crystal storage and deuterium tank, have now indexes 7, 8, 9.