### PR TITLE
Spyreports function fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ reports = empire.spyreports()
 report = reports[0]
 report.name                                   returns str
 report.position                               returns list
+report.moon                                   returns bool
 report.datetime                               returns str
 report.metal                                  returns int
 report.crystal                                returns int

--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -1125,13 +1125,7 @@ class OGame(object):
             bs4 = BeautifulSoup4(response)
             for link in bs4.find_all_partial(href='page=messages&messageId'):
                 if link['href'] not in report_links:
-                    report_links.extend(
-                        [
-                            link['href']
-                            for link in bs4.find_all_partial(
-                                href='page=messages&messageId')
-                        ]
-                    )
+                    report_links.append(link['href'])
             firstpage += 1
         reports = []
         for link in report_links:

--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -1137,10 +1137,9 @@ class OGame(object):
             planet_coords = bs4.find('span', 'msg_title').find('a')
             if planet_coords is None:
                 continue
-            planet_coords = re.search(r'(.*?) \[(.*?)\]', planet_coords.text)
+            planet_coords = re.search(r'(.*?) (\[(.*?)])', planet_coords.text)
             report_datetime = bs4.find('span', 'msg_date').text
             api_code = bs4.find('span', 'icon_apikey')['title']
-            api_code = re.search(r'value=\'(.+?)\'', api_code).group(1)
             resources_data = {}
             for resource in resources_list.find_all('li'):
                 resource_name = resource.find('div')['class']
@@ -1175,7 +1174,8 @@ class OGame(object):
 
             class Report:
                 name = planet_coords.group(1)
-                position = planet_coords.group(2)
+                position = const.convert_to_coordinates(planet_coords.group(2))
+                moon = bs4.find('figure', 'moon') is not None
                 datetime = report_datetime
                 metal = resources_data['metal']
                 crystal = resources_data['crystal']
@@ -1185,9 +1185,9 @@ class OGame(object):
                 defenses = spied_data['defense']
                 buildings = spied_data['buildings']
                 research = spied_data['research']
-                api = api_code
+                api = re.search(r'value=\'(.+?)\'', api_code).group(1)
                 list = [
-                    name, position, datetime, metal,
+                    name, position, moon, datetime, metal,
                     crystal, deuterium, resources, fleet,
                     defenses, buildings, research, api
                 ]


### PR DESCRIPTION
I think we missed something...

I'm not quite sure how this is worked so far but those lines:
https://github.com/alaingilbert/pyogame/blob/1af2ade069b3e0644063064f7e7ae41127168f26/ogame/__init__.py#L982-L984
should mess up with the code, they extend the report_link array multiple times, creating duplicates.
Both master and develop branch have this bug.

I noticed this while trying to implement an expedition_report function, same code, and I got hundreds more reports than I currently had.

Also, I fixed other problems like report coordinates being str instead of list and the missing moon parameter (it was impossible to determine if the report was from a planet or a moon)