### PR TITLE
adding buddy_msg, jump_fleet, rewards, ingame msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-  # pyogame
+ # pyogame
 <img src="https://github.com/alaingilbert/pyogame/blob/develop/logo.png?raw=true" width="300" alt="logo">
 
 OGame is a browser-based, money-management and space-war themed massively multiplayer online browser game with over 
@@ -571,7 +571,7 @@ will return the remaining seconds as an int.
 ```python
 empire.jump_fleet(origin_id=id_1,
                   target_id=id_2,
-                  ships=fleet(light_fighter=12, bomber=1, cruiser=100)
+                  ships=fleet(light_fighter=12, bomber=1, cruiser=100))
 ```
 
 ### get spyreports
@@ -668,8 +668,10 @@ items.rewards                                 returns list
 items.event_progress                          returns list ([4, 7], day 4 from 7 in total)
 items.list                                    returns list
 
+example:
 items.rewards  returns ([('Metal', '4.500.000', '1'), ('Crystal', '3.000.000', '2'), ('Deuterium', '1.500.000', '3')],
                         [('Commander', '4 days', '9'), ('Admiral', '4 days', '10'), ('Engineer', '4 days', '11')])
+
 
 empire.rewards(tier=int, reward=int)          returns list of class(object) / bool
 
@@ -684,13 +686,7 @@ if isinstance(claimed_reward, type(list)):
     claimed_reward.id                         returns str (item id in reward system)
 else:
     claimed_reward                            returns bool
-
 </pre>
-
-```python
-for message in empire.get_messages():
-    print(message.list)
-```
 
 ### build
 Buildings

--- a/README.md
+++ b/README.md
@@ -655,6 +655,9 @@ items.list                                    returns list
 
 empire.rewards(tier=int, reward=int)          returns list of class(object) / [bool, "Error-Code"]
 
+The desired reward level should be inserted at tier.
+The reward that should be claimed at reward. (in case of three available items, 1=left, 2=middle, 3=right item)  
+
 claimed_reward = empire.rewards(tier=int, reward=int)
 if isinstance(claimed_reward, type(list)):
     claimed_reward.status                     returns bool

--- a/README.md
+++ b/README.md
@@ -650,12 +650,13 @@ items = empire.rewards()
 items.highest_tier                            returns int  (7)
 items.claimable                               returns list ([1, 2, 3, 4])
 items.rewards                                 returns list
-output: ([('Metal', '4.500.000', '1'), ('Crystal', '3.000.000', '2'), ('Deuterium', '1.500.000', '3')],
-         [('Commander', '4 days', '9'), ('Admiral', '4 days', '10'), ('Engineer', '4 days', '11')])
 items.event_progress                          returns list ([4, 7], day 4 from 7 in total)
 items.list                                    returns list
 
-empire.rewards(tier=int, reward=int)          returns list of class(object) / [bool, "Error-Code"]
+items.rewards  returns ([('Metal', '4.500.000', '1'), ('Crystal', '3.000.000', '2'), ('Deuterium', '1.500.000', '3')],
+                        [('Commander', '4 days', '9'), ('Admiral', '4 days', '10'), ('Engineer', '4 days', '11')])
+
+empire.rewards(tier=int, reward=int)          returns list of class(object) / bool
 
 The desired reward level should be inserted at tier.
 The reward that should be claimed at reward. (in case of three available items, 1=left, 2=middle, 3=right item)  
@@ -667,9 +668,8 @@ if isinstance(claimed_reward, type(list)):
     claimed_reward.amount                     returns str (amount of items)
     claimed_reward.id                         returns str (item id in reward system)
 else:
-    claimed_reward[0]                         returns bool
-    claimed_reward[1]                         returns str (Error: "Not enough tritium!",
-                                                                  "Tier exceeds maximum!")
+    claimed_reward                            returns bool
+
 </pre>
 
 ```python

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- # pyogame
+  # pyogame
 <img src="https://github.com/alaingilbert/pyogame/blob/develop/logo.png?raw=true" width="300" alt="logo">
 
 OGame is a browser-based, money-management and space-war themed massively multiplayer online browser game with over 
@@ -89,6 +89,14 @@ Get the class of your Ogame Account['miner', 'explorer', 'warrior', 'none]
 empire.character_class()            return string
 </pre>
 
+### chose characterclass
+<pre>
+from ogame.constants import character_class
+empire.choose_character_class(
+    character_class.miner
+)                                   return bool
+</pre>
+
 ### get rank
 <pre>
 empire.rank()                       return int
@@ -98,11 +106,13 @@ empire.rank()                       return int
 <pre>
 empire.planet_ids()                 returns list 
 
+empire.planet_names()               returns list
+
+empire.planet_coords()              returns list
+
 empire.id_by_planet_name('name')    returns int
 
 empire.name_by_planet_id(id)        return string
-
-empire.planet_names()               returns list
 </pre>
 
 ### get moon id's
@@ -110,6 +120,10 @@ empire.planet_names()               returns list
 empire.moon_ids()                   returns list
 
 empire.moon_names()                 returns list
+
+empire.moon_coords()                returns list
+
+empire.id_by_moon_name('name')      returns int
 
 **keep in mind to prefer planets id's moon id dont works on every function**
 </pre>
@@ -169,9 +183,11 @@ celestial = empire.celestial(id)        returns class
 celestial.temperature                   returns list
 celestial.diameter                      returns int
 celestial.coordinates                   returns list
-celestial.used                          return int
-celestial.total                         return int
-celestial.free                          return int
+celestial.used                          returns int
+celestial.total                         returns int
+celestial.free                          returns int
+celestial.points                        returns int
+celestial.rank                          returns int
 </pre>
 
 ### get celestial coordinates
@@ -288,7 +304,9 @@ sup.metal_mine.in_construction          returns bool
 sup.crystal_mine
 sup.deuterium_mine
 sup.solar_plant
-sup.fusion_plant 
+sup.fusion_plant
+sup.solar_satellite
+sup.crawler
 sup.metal_storage
 sup.crystal_storage
 sup.deuterium_storage                   returns class(object)
@@ -606,18 +624,15 @@ You can't return hostile Fleets :p use the friendly fleet function to avoid conf
 True if the Fleet you want to return is possible to retreat
 </pre>
 
-
 ### send message
 <pre>
 empire.send_message(player_id, msg)     returns bool
 </pre>
 
-
 ### send buddy request
 <pre>
 empire.send_buddy(player_id, msg)       returns bool
 </pre>
-
 
 ### get messages
 <pre>

--- a/README.md
+++ b/README.md
@@ -542,6 +542,20 @@ for fleet in empire.phalanx(moon_id, coordinates(2, 410, 7)):
         print(fleet.id, fleet.mission, fleet.returns, fleet.arrival, fleet.origin, fleet.destination)
 ```
 
+### jump fleet
+<pre>
+empire.jump_fleet(origin_id, target_id, ships)  returns bool / int (cooldown in sec)
+
+Jumpgate is required on both moons, if there is a cooldown the function
+will return the remaining seconds as an int. 
+</pre>
+
+```python
+empire.jump_fleet(origin_id=id_1,
+                  target_id=id_2,
+                  ships=fleet(light_fighter=12, bomber=1, cruiser=100)
+```
+
 ### get spyreports
 <pre>
 empire.spyreports()                           returns list of class(object)
@@ -596,6 +610,12 @@ True if the Fleet you want to return is possible to retreat
 ### send message
 <pre>
 empire.send_message(player_id, msg)     returns bool
+</pre>
+
+
+### send buddy request
+<pre>
+empire.send_buddy(player_id, msg)       returns bool
 </pre>
 
 

--- a/README.md
+++ b/README.md
@@ -649,8 +649,10 @@ empire.rewards()                              returns list of class(object)
 items = empire.rewards() 
 items.highest_tier                            returns int  (7)
 items.claimable                               returns list ([1, 2, 3, 4])
-items.rewards                                 returns list (["Commander", "Admiral", "Geologist", ..])
-items.event_progress                          returns list ([4, 7] day 4 from 7 in total)
+items.rewards                                 returns list
+output: ([('Metal', '4.500.000', '1'), ('Crystal', '3.000.000', '2'), ('Deuterium', '1.500.000', '3')],
+         [('Commander', '4 days', '9'), ('Admiral', '4 days', '10'), ('Engineer', '4 days', '11')])
+items.event_progress                          returns list ([4, 7], day 4 from 7 in total)
 items.list                                    returns list
 
 empire.rewards(tier=int, reward=int)          returns list of class(object) / [bool, "Error-Code"]

--- a/README.md
+++ b/README.md
@@ -619,6 +619,59 @@ empire.send_buddy(player_id, msg)       returns bool
 </pre>
 
 
+### get messages
+<pre>
+empire.get_messages()                         returns list of class(object)
+
+messages = empire.get_messages()
+message = messages[0]
+message.player                                returns str
+message.player_id                             returns int
+message.status  (amount of unread messages)   returns int
+message.text    (text of latest message)      returns str
+message.time                                  returns str
+message.alliance                              returns str
+message.rank                                  returns int
+message.chat    (chat history of last 10 msg) returns list
+message.list                                  returns list
+</pre>
+
+```python
+for message in empire.get_messages():
+    print(message.list)
+```
+
+### rewards
+<pre>
+empire.reward_system()                        returns bool (reward system online/offline)
+empire.rewards()                              returns list of class(object)
+
+items = empire.rewards() 
+items.highest_tier                            returns int  (7)
+items.claimable                               returns list ([1, 2, 3, 4])
+items.rewards                                 returns list (["Commander", "Admiral", "Geologist", ..])
+items.event_progress                          returns list ([4, 7] day 4 from 7 in total)
+items.list                                    returns list
+
+empire.rewards(tier=int, reward=int)          returns list of class(object) / [bool, "Error-Code"]
+
+claimed_reward = empire.rewards(tier=int, reward=int)
+if isinstance(claimed_reward, type(list)):
+    claimed_reward.status                     returns bool
+    claimed_reward.name                       returns str
+    claimed_reward.amount                     returns str (amount of items)
+    claimed_reward.id                         returns str (item id in reward system)
+else:
+    claimed_reward[0]                         returns bool
+    claimed_reward[1]                         returns str (Error: "Not enough tritium!",
+                                                                  "Tier exceeds maximum!")
+</pre>
+
+```python
+for message in empire.get_messages():
+    print(message.list)
+```
+
 ### build
 Buildings
 ```python

--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -1111,17 +1111,15 @@ class OGame(object):
                   'text': msg},
             headers={'X-Requested-With': 'XMLHttpRequest'}
         )
-        try:
-            response = response.json()
-        except:
-            print("Already unanswered Buddy-Message ")     # no .json() when trying to send multiple messages to the same player
-            return False
-        if 'OK' in response['status']:
+        bs4 = BeautifulSoup4(response.text)
+        content = bs4.find('div', class_="buddylistContent")
+        if content.table:
             return True
         else:
+            print(" ".join(content.text.split()))            # output 'You have already sent a request to this player.' / 'Invalid player.'
             return False
 
-    def reward_system(self):                  # check if reward system is online
+    def reward_system(self):                                 # check if reward system is online
         bs4 = self.landing_page
         menue = bs4.find_all('span', class_='textlabel')
         if "Rewards" in [title.text for title in menue]:

--- a/ogame/__init__.py
+++ b/ogame/__init__.py
@@ -1053,7 +1053,7 @@ class OGame(object):
         if str(target_id) not in possible_dest:
             ready = re.search(r' <div id="(.*)"', response1.text)
             if ready:
-                print(" JumpGate not ready!")      # maybe change these lines and add an cooldown_timer
+                print(" JumpGate not ready!")      # maybe change these lines and add a cooldown_timer
             return False
         form_data = {'token': jump_token,
                      'zm': target_id}


### PR DESCRIPTION
# Buddy
- send buddy message like normal messages

# Jump_fleets
- jump fleet between moons, simply input ids from origin_moon, target_moon and ships_list (same like sending an fleet)

# Rewards
- super tideous but somehow works, input the tier and the wanted reward (probably needs more explanation)
- calling rewards() gives a list with all tiers and so on, which makes claiming specific rewards possible

# Ingame messages
- list all latest ingame messages + chat_history if a new message is received